### PR TITLE
Bug: Speed Increase after first collision when calling requestAnimationFrame

### DIFF
--- a/src/components/game/Game.js
+++ b/src/components/game/Game.js
@@ -173,12 +173,11 @@ class Game extends React.Component {
     }
 
     gameLoop() {
+        this.requestId = window.requestAnimationFrame(this.gameLoop.bind(this));
+        
         let node = React.findDOMNode(this._gameSurface);
-
         this.update();
         this.paint(node.getContext('2d'));
-
-        this.requestId = window.requestAnimationFrame(this.gameLoop.bind(this), node);
     }
 
     update() {


### PR DESCRIPTION
Updated the gameLoop to call update after the reference to requestAnimationFrame has been made instead of before.

Calling update before was resulting in a 2x speed increase after the first restart as the previous requestAnimationFrame was not being cancelled.
